### PR TITLE
Adiciona documentos-guia/ ao .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ jspm_packages/
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/
 
+# Pasta de documentos guia
+documentos-guia/
+
 # TypeScript cache
 *.tsbuildinfo
 


### PR DESCRIPTION
Galera, vou adicionar aqui uma exceção de uma pasta. Não é pra incluir no projeto.