### PR TITLE
chore(ci): reorganiza configuração do workflow para incluir serviços …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,26 @@ on:
   pull_request:
     branches: [main]
 
+
 jobs:
   test:
     name: Testes automatizados
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: Dgll4GMEYxuSO9nT
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
     defaults:
       run:
         working-directory: backend
+    env:
+      DATABASE_URL: "postgresql://postgres:Dgll4GMEYxuSO9nT@localhost:5432/postgres"
+      JWT_KEY: ${{ secrets.JWT_KEY }}
 
     steps:
       - name: Checkout do código
@@ -30,14 +43,12 @@ jobs:
 
       - name: Gerar Prisma Client
         run: npx prisma generate
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      - name: Rodar migrations
+        run: npx prisma migrate deploy
 
       - name: Executar testes
         run: npm test
-        env:
-          JWT_KEY: ${{ secrets.JWT_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
   deploy:
     name: Deploy no Render


### PR DESCRIPTION
Este pull request reorganiza o workflow de CI/CD para garantir testes automatizados seguros e isolados, incluindo:

Adição do serviço Postgres local no GitHub Actions para rodar testes sem depender do banco de produção/Supabase.
Configuração das variáveis de ambiente (DATABASE_URL e JWT_KEY) para o ambiente de testes.
Execução das migrations do Prisma antes dos testes, garantindo o schema atualizado.
Ajuste das etapas do workflow para rodar testes com o banco local, aumentando a confiabilidade do CI.
Com isso, os testes automatizados passam a rodar em um ambiente controlado, evitando riscos à produção e facilitando a validação de novas features.

Se quiser adaptar, pode incluir detalhes como:

“Seguindo o padrão de branches e PRs do projeto.”
“Validação local realizada antes do push.”
Se precisar de um texto mais curto ou técnico, avise!