### PR TITLE
fix(ci): adiciona espera para o Postgres estar pronto antes de rodar …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,13 @@ jobs:
       - name: Gerar Prisma Client
         run: npx prisma generate
 
+      - name: Esperar Postgres estar pronto
+        run: |
+          until pg_isready -h localhost -p 5432; do
+            echo "Aguardando Postgres...";
+            sleep 2;
+          done
+
       - name: Rodar migrations
         run: npx prisma migrate deploy
 


### PR DESCRIPTION


Este PR adiciona uma etapa ao workflow de CI/CD para aguardar o serviço Postgres estar pronto antes de rodar as migrations e os testes automatizados.
Com isso, evitamos erros de inicialização do Prisma Client causados por tentativas de conexão antes do banco estar disponível.

Adiciona comando pg_isready para garantir que o Postgres está aceitando conexões.
Garante que as migrations e os testes só rodem após o banco estar pronto.
Melhora a confiabilidade dos testes automatizados no GitHub Actions.