### PR TITLE
Atualizei a versão do Node.js nos engines de "22.x" para "18.x" para garantir compatibilidade com o Vercel

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "web-vitals": "^2.1.4"
       },
       "engines": {
-        "node": "22.x"
+        "node": "18.x"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
Atualizei a versão do Node.js nos engines de "22.x" para "18.x" para garantir compatibilidade com o Vercel (que não suporta versões mais recentes como 22.x no momento do deploy).