### PR TITLE
O backend estava com cors() sem configuração específica

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,7 +7,18 @@ const errorMiddleware = require("./middlewares/error-middleware");
 const { swaggerUi, swaggerSpec } = require("./swagger");
 
 const app = express();
-app.use(cors());
+
+// Configuração de CORS para aceitar requisições do frontend
+const corsOptions = {
+  origin: [
+    "http://localhost:3000",      // Desenvolvimento local
+    "http://localhost:5173",      // Vite dev (se usado)
+    "https://biblioteca-emprestimos-cloud.vercel.app", // Vercel production
+  ],
+  credentials: true,
+};
+
+app.use(cors(corsOptions));
 app.use(morgan('dev'));
 app.use(express.json());
 app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));


### PR DESCRIPTION
O backend estava com [cors()](https://musical-waffle-q5wx99vwwx7f4rj6.github.dev/) sem configuração específica, e o Render pode estar interpretando isso de forma restritiva ou com cache. A origem da Vercel (https://biblioteca-emprestimos-cloud.vercel.app) não estava autorizada.