### PR TITLE
remove enriquecimento paralelo e ajuste nas chaves de consulta

### DIFF
--- a/frontend/src/pages/Catalogo.jsx
+++ b/frontend/src/pages/Catalogo.jsx
@@ -141,25 +141,8 @@ function Catalogo() {
               <div className="catalogo-grid fade-in">
                 {livrosFiltrados.map((livro) => (
                   <div key={livro.id} className="catalogo-card">
-                    <div className="catalogo-capa">
-                      <span className="catalogo-capa-fallback" aria-hidden="true">
-                        📖
-                      </span>
-                      {livro.urlCapa && (
-                        <img
-                          src={livro.urlCapa}
-                          alt={`Capa do livro ${livro.titulo}`}
-                          className="catalogo-capa-img"
-                          loading="lazy"
-                          onError={(e) => {
-                            e.currentTarget.style.display = 'none';
-                          }}
-                        />
-                      )}
-                    </div>
                     <h3>{livro.titulo}</h3>
                     <p className="catalogo-autor">{livro.autor}</p>
-                    <p className="catalogo-genero">{livro.genero}</p>
                     
                     <div className="catalogo-disponibilidade">
                       {livro.disponiveis > 0 ? (

--- a/frontend/src/services/hooks.js
+++ b/frontend/src/services/hooks.js
@@ -12,11 +12,10 @@ import { fetchBookMetadataByTitleAuthor } from './googleBooks';
  */
 export function useBooksWithGoogle() {
   return useQuery({
-    queryKey: ['books', 'google'],
+    queryKey: ['books'],
     queryFn: async () => {
       const books = await fetchBooksWithDetails();
-      // Enriquece em paralelo (limite de 5)
-      return enrichBooksInParallel(books, 5);
+      return books;
     },
     staleTime: 3 * 60 * 1000, // 3 minutos
     gcTime: 5 * 60 * 1000, // 5 minutos
@@ -28,20 +27,19 @@ export function useBooksWithGoogle() {
  */
 export function useBooksWithGooglePaginated(page = 1, pageSize = 12) {
   return useQuery({
-    queryKey: ['books', 'google', 'paginated', page, pageSize],
+    queryKey: ['books', 'paginated', page, pageSize],
     queryFn: async () => {
       const books = await fetchBooksWithDetails();
-      const enriched = await enrichBooksInParallel(books, 5);
       
       const startIdx = (page - 1) * pageSize;
       const endIdx = startIdx + pageSize;
       
       return {
-        data: enriched.slice(startIdx, endIdx),
-        total: enriched.length,
+        data: books.slice(startIdx, endIdx),
+        total: books.length,
         page,
         pageSize,
-        hasMore: endIdx < enriched.length,
+        hasMore: endIdx < books.length,
       };
     },
     staleTime: 3 * 60 * 1000,
@@ -54,14 +52,12 @@ export function useBooksWithGooglePaginated(page = 1, pageSize = 12) {
  */
 export function useBookWithGoogle(bookId) {
   return useQuery({
-    queryKey: ['book', bookId, 'google'],
+    queryKey: ['book', bookId],
     queryFn: async () => {
       const book = await fetchBookDetails(bookId);
-      const metadata = await fetchBookMetadataByTitleAuthor(book.titulo, book.autor);
       return {
         ...book,
-        ...metadata,
-        genero: metadata?.categorias || book.genero,
+        genero: book.genero || 'N/A',
       };
     },
     enabled: !!bookId,


### PR DESCRIPTION
Agora, o Card de cada livro no banco exibirá APENAS:
- Título
- Autor
- Badge de "Disponível" / "Indisponível"
- Quantidade disponível de cópias

A capa e o gênero que chamavam as imagens e as descrições da Google Books API foram removidos na visualização em grade. Quando o usuário clicar em **"Ver Detalhes"**, a página individual de detalhes (em LivroDetalhe.jsx)  chamará a API separadamente para buscar essas informações faltantes sob demanda, garantindo um carregamento do catálogo muito mais rápido e sem o erro 429!